### PR TITLE
Add support for special `_enabled` configuration key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
           - "3.10"
           - "3.11"
         ansible:
-          - 6
           - 7
           - 8
+          - 9
         distro:
           - ubuntu2004
           - ubuntu2204

--- a/molecule/default/files/ansible-inputs.conf
+++ b/molecule/default/files/ansible-inputs.conf
@@ -15,6 +15,8 @@
 
 [[inputs.mem]]
 
+[[inputs.processes]]
+
 [[inputs.swap]]
 
 [[inputs.system]]

--- a/molecule/default/inventory/group_vars/all.yml
+++ b/molecule/default/inventory/group_vars/all.yml
@@ -5,6 +5,11 @@ telegraf_group_inputs:
   cpu:
     collect_cpu_time: true
     percpu: false
+  filestat:
+    files:
+      - "/var/log/**.log"
+  processes:
+    _enabled: "{{ inventory_hostname == 'instance' }}"
 
 telegraf_processors:
   regex:

--- a/molecule/default/inventory/host_vars/instance.yml
+++ b/molecule/default/inventory/host_vars/instance.yml
@@ -17,6 +17,8 @@ telegraf_host_inputs:
   cpu:
     totalcpu: true
     percpu: true
+  filestat:
+    _enabled: "{{ inventory_hostname != 'instance' }}"
 
 telegraf_host_processors:
   regex:

--- a/templates/telegraf-macros.j2
+++ b/templates/telegraf-macros.j2
@@ -1,9 +1,9 @@
 #jinja2: trim_blocks: True, lstrip_blocks: True
 
 {% macro telegraf_section(section_config, prefix='output') -%}
-{% for name, config in section_config|dictsort %}
+{% for name, config in section_config|dictsort if config._enabled|d(True)|bool %}
 [[{{ prefix }}.{{ config._name|d(name) }}]]
-{%   for key, value in config|dictsort if key != "_name" %}
+{%   for key, value in config|dictsort if key not in ['_name', '_enabled'] %}
 {%     if value is mapping %}
   [[{{ prefix }}.{{ config._name|d(name) }}.{{ value._name|d(key) }}]]
 {%       for k, v in value|dictsort if k != "_name" %}

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 minversion = 4.2.4
-envlist = py{310,311}-ansible{6,7,8}
+envlist = py{310,311}-ansible{7,8,9}
 skipsdist = true
 
 [testenv]
 commands = molecule test
 deps =
-    ansible6: ansible == 6.*
     ansible7: ansible == 7.*
     ansible8: ansible == 8.*
+    ansible9: ansible == 9.*
     molecule-plugins[docker]
     docker == 6.*
     ansible-lint == 6.*


### PR DESCRIPTION
Based on @zas' alternative approach proposed in PR #9, with a minor change to the key name from `_disabled` to `_enabled`.

This isn't a perfect solution as it only support top level keys, but this shouldn't be an issue for our use cases.